### PR TITLE
initial commit of costmap clearing patch

### DIFF
--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -287,6 +287,12 @@ void ControllerServer::computeControl()
         publishZeroVelocity();
         return;
       }
+      
+      // Don't compute a trajectory until costmap is valid (after clear costmap)
+      rclcpp::Rate r(100);
+      while (!costmap_ros_->isCurrent()) {
+        r.sleep();
+      }
 
       updateGlobalPath();
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
@@ -39,10 +39,7 @@ public:
   ClearCostmapService() = delete;
 
   // Clears the region outside of a user-specified area reverting to the static map
-  void clearExceptRegion(double reset_distance = 3.0);
-
-  // Clears within a window around the robot
-  void clearAroundRobot(double window_size_x, double window_size_y);
+  void clearRegion(double reset_distance, bool invert);
 
   // Clears all layers
   void clearEntirely();
@@ -77,14 +74,11 @@ private:
     const std::shared_ptr<nav2_msgs::srv::ClearEntireCostmap::Request> request,
     const std::shared_ptr<nav2_msgs::srv::ClearEntireCostmap::Response> response);
 
-  void clearLayerExceptRegion(
-    std::shared_ptr<CostmapLayer> & costmap, double pose_x, double pose_y, double reset_distance);
-
-  bool isClearable(const std::string & layer_name) const;
+  void clearLayerRegion(
+    std::shared_ptr<CostmapLayer> & costmap, double pose_x, double pose_y, double reset_distance,
+    bool invert);
 
   bool getPosition(double & x, double & y) const;
-
-  std::string getLayerName(const Layer & layer) const;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
@@ -60,7 +60,7 @@ public:
 
   virtual void matchSize();
 
-  virtual void clearArea(int start_x, int start_y, int end_x, int end_y);
+  virtual void clearArea(int start_x, int start_y, int end_x, int end_y, bool invert);
 
   /**
    * If an external source changes values in the costmap,

--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -91,10 +91,12 @@ public:
     int min_i, int min_j, int max_i, int max_j) override;
 
   void matchSize() override;
+  virtual bool isClearable() {return false;}
 
   void reset() override
   {
     matchSize();
+    current_ = false;
   }
 
   /** @brief  Given a distance, compute a cost.

--- a/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
@@ -68,6 +68,7 @@ public:
   virtual void deactivate() {} /** @brief Stop publishers. */
   virtual void activate() {}   /** @brief Restart publishers if they've been stopped. */
   virtual void reset() = 0;
+  virtual bool isClearable() = 0;
 
   /**
    * @brief This is called by the LayeredCostmap to poll this plugin as to how

--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -83,6 +83,8 @@ public:
   virtual void activate();
   virtual void deactivate();
   virtual void reset();
+  virtual bool isClearable() {return true;}
+  
   /**
    * @brief triggers the update of observations buffer
    */
@@ -185,6 +187,7 @@ protected:
   std::vector<nav2_costmap_2d::Observation> static_marking_observations_;
 
   bool rolling_window_;
+  bool was_reset_;
   int combination_method_;
 };
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/range_sensor_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/range_sensor_layer.hpp
@@ -75,6 +75,7 @@ public:
   virtual void reset();
   virtual void deactivate();
   virtual void activate();
+  virtual bool isClearable() {return true;}
 
   void bufferIncomingRangeMsg(const sensor_msgs::msg::Range::SharedPtr range_message);
 
@@ -116,6 +117,7 @@ private:
 
   double clear_threshold_, mark_threshold_;
   bool clear_on_max_reading_;
+  bool was_reset_;
 
   tf2::Duration transform_tolerance_;
   double no_readings_timeout_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
@@ -61,6 +61,7 @@ public:
   virtual void activate();
   virtual void deactivate();
   virtual void reset();
+  virtual bool isClearable() {return false;}
 
   virtual void updateBounds(
     double robot_x, double robot_y, double robot_yaw, double * min_x,

--- a/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
@@ -80,6 +80,7 @@ public:
   }
   virtual void matchSize();
   virtual void reset();
+  virtual bool isClearable() {return true;}
 
 protected:
   virtual void resetMaps();

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -275,6 +275,8 @@ InflationLayer::updateCosts(
     dist.clear();
     dist.reserve(200);
   }
+  
+  current_ = true;
 }
 
 /**

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -103,6 +103,7 @@ void ObstacleLayer::onInitialize()
 
   ObstacleLayer::matchSize();
   current_ = true;
+  was_reset_ = false;
 
   global_frame_ = layered_costmap_->getGlobalFrameID();
 
@@ -438,6 +439,12 @@ ObstacleLayer::updateCosts(
   if (!enabled_) {
     return;
   }
+  
+  // if not current due to reset, set current now after clearing
+  if (!current_ && was_reset_) {
+    was_reset_ = false;
+    current_ = true;
+  }
 
   if (footprint_clearing_enabled_) {
     setConvexPolygonCost(transformed_footprint_, nav2_costmap_2d::FREE_SPACE);
@@ -642,7 +649,8 @@ ObstacleLayer::reset()
 {
   resetMaps();
   resetBuffersLastUpdated();
-  current_ = true;
+  current_ = false;
+  was_reset_ = true;
 }
 
 void

--- a/nav2_costmap_2d/plugins/range_sensor_layer.cpp
+++ b/nav2_costmap_2d/plugins/range_sensor_layer.cpp
@@ -60,6 +60,7 @@ RangeSensorLayer::RangeSensorLayer() {}
 void RangeSensorLayer::onInitialize()
 {
   current_ = true;
+  was_reset_ = false;
   buffered_readings_ = 0;
   last_reading_time_ = node_->now();
   default_value_ = to_cost(0.5);
@@ -499,7 +500,12 @@ void RangeSensorLayer::updateCosts(
   }
 
   buffered_readings_ = 0;
-  current_ = true;
+  
+  // if not current due to reset, set current now after clearing
+  if (!current_ && was_reset_) {
+    was_reset_ = false;
+    current_ = true;
+  }
 }
 
 void RangeSensorLayer::reset()
@@ -507,7 +513,7 @@ void RangeSensorLayer::reset()
   RCLCPP_DEBUG(node_->get_logger(), "Reseting range sensor layer...");
   deactivate();
   resetMaps();
-  current_ = true;
+  was_reset_ = true;
   activate();
 }
 

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -112,6 +112,7 @@ void
 StaticLayer::reset()
 {
   has_updated_data_ = true;
+  current_ = false;
 }
 
 void
@@ -422,6 +423,7 @@ StaticLayer::updateCosts(
     }
   }
   update_in_progress_.store(false);
+  current_ = true;
 }
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -68,7 +68,7 @@ void ClearCostmapService::clearExceptRegionCallback(
     node_->get_logger(),
     "Received request to clear except a region the " + costmap_.getName());
 
-  clearExceptRegion(request->reset_distance);
+  clearRegion(request->reset_distance, true);
 }
 
 void ClearCostmapService::clearAroundRobotCallback(
@@ -76,16 +76,7 @@ void ClearCostmapService::clearAroundRobotCallback(
   const shared_ptr<ClearAroundRobot::Request> request,
   const shared_ptr<ClearAroundRobot::Response>/*response*/)
 {
-  RCLCPP_INFO(
-    node_->get_logger(),
-    "Received request to clear around robot the " + costmap_.getName());
-
-  if ((request->window_size_x == 0) || (request->window_size_y == 0)) {
-    clearEntirely();
-    return;
-  }
-
-  clearAroundRobot(request->window_size_x, request->window_size_y);
+  clearRegion(request->reset_distance, false);
 }
 
 void ClearCostmapService::clearEntireCallback(
@@ -98,7 +89,7 @@ void ClearCostmapService::clearEntireCallback(
   clearEntirely();
 }
 
-void ClearCostmapService::clearExceptRegion(const double reset_distance)
+void ClearCostmapService::clearRegion(const double reset_distance, bool invert)
 {
   double x, y;
 
@@ -110,57 +101,16 @@ void ClearCostmapService::clearExceptRegion(const double reset_distance)
   auto layers = costmap_.getLayeredCostmap()->getPlugins();
 
   for (auto & layer : *layers) {
-    if (isClearable(getLayerName(*layer))) {
+    if (layer->isClearable()) {
       auto costmap_layer = std::static_pointer_cast<CostmapLayer>(layer);
-      clearLayerExceptRegion(costmap_layer, x, y, reset_distance);
+      clearLayerRegion(costmap_layer, x, y, reset_distance, invert);
     }
   }
 }
 
-void ClearCostmapService::clearAroundRobot(double window_size_x, double window_size_y)
-{
-  double pose_x, pose_y;
-
-  if (!getPosition(pose_x, pose_y)) {
-    RCLCPP_ERROR(node_->get_logger(), "Cannot clear map because robot pose cannot be retrieved.");
-    return;
-  }
-
-  std::vector<geometry_msgs::msg::Point> clear_poly;
-  geometry_msgs::msg::Point pt;
-
-  pt.x = pose_x - window_size_x / 2;
-  pt.y = pose_y - window_size_y / 2;
-  clear_poly.push_back(pt);
-
-  pt.x = pose_x + window_size_x / 2;
-  pt.y = pose_y - window_size_y / 2;
-  clear_poly.push_back(pt);
-
-  pt.x = pose_x + window_size_x / 2;
-  pt.y = pose_y + window_size_y / 2;
-  clear_poly.push_back(pt);
-
-  pt.x = pose_x - window_size_x / 2;
-  pt.y = pose_y + window_size_y / 2;
-  clear_poly.push_back(pt);
-
-  costmap_.getCostmap()->setConvexPolygonCost(clear_poly, reset_value_);
-}
-
-void ClearCostmapService::clearEntirely()
-{
-  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getCostmap()->getMutex()));
-  costmap_.resetLayers();
-}
-
-bool ClearCostmapService::isClearable(const string & layer_name) const
-{
-  return count(begin(clearable_layers_), end(clearable_layers_), layer_name) != 0;
-}
-
-void ClearCostmapService::clearLayerExceptRegion(
-  shared_ptr<CostmapLayer> & costmap, double pose_x, double pose_y, double reset_distance)
+void ClearCostmapService::clearLayerRegion(
+  shared_ptr<CostmapLayer> & costmap, double pose_x, double pose_y, double reset_distance,
+  bool invert)
 {
   std::unique_lock<Costmap2D::mutex_t> lock(*(costmap->getMutex()));
 
@@ -173,22 +123,17 @@ void ClearCostmapService::clearLayerExceptRegion(
   costmap->worldToMapNoBounds(start_point_x, start_point_y, start_x, start_y);
   costmap->worldToMapNoBounds(end_point_x, end_point_y, end_x, end_y);
 
-  unsigned int size_x = costmap->getSizeInCellsX();
-  unsigned int size_y = costmap->getSizeInCellsY();
-
-  // Clearing the four rectangular regions around the one we want to keep
-  // top region
-  costmap->resetMapToValue(0, 0, size_x, start_y, reset_value_);
-  // left region
-  costmap->resetMapToValue(0, start_y, start_x, end_y, reset_value_);
-  // right region
-  costmap->resetMapToValue(end_x, start_y, size_x, end_y, reset_value_);
-  // bottom region
-  costmap->resetMapToValue(0, end_y, size_x, size_y, reset_value_);
+  costmap->clearArea(start_x, start_y, end_x, end_y, invert);
 
   double ox = costmap->getOriginX(), oy = costmap->getOriginY();
   double width = costmap->getSizeInMetersX(), height = costmap->getSizeInMetersY();
   costmap->addExtraBounds(ox, oy, ox + width, oy + height);
+}
+
+void ClearCostmapService::clearEntirely()
+{
+  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getCostmap()->getMutex()));
+  costmap_.resetLayers();
 }
 
 bool ClearCostmapService::getPosition(double & x, double & y) const
@@ -202,19 +147,6 @@ bool ClearCostmapService::getPosition(double & x, double & y) const
   y = pose.pose.position.y;
 
   return true;
-}
-
-string ClearCostmapService::getLayerName(const Layer & layer) const
-{
-  string name = layer.getName();
-
-  size_t slash = name.rfind('/');
-
-  if (slash != std::string::npos) {
-    name = name.substr(slash + 1);
-  }
-
-  return name;
 }
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -61,14 +61,15 @@ void CostmapLayer::matchSize()
     master->getOriginX(), master->getOriginY());
 }
 
-void CostmapLayer::clearArea(int start_x, int start_y, int end_x, int end_y)
+void CostmapLayer::clearArea(int start_x, int start_y, int end_x, int end_y, bool invert)
 {
+  current_ = false;
   unsigned char * grid = getCharMap();
   for (int x = 0; x < static_cast<int>(getSizeInCellsX()); x++) {
     bool xrange = x > start_x && x < end_x;
 
     for (int y = 0; y < static_cast<int>(getSizeInCellsY()); y++) {
-      if (xrange && y > start_y && y < end_y) {
+      if ((xrange && y > start_y && y < end_y) != invert) {
         continue;
       }
       int index = getIndex(x, y);

--- a/nav2_msgs/srv/ClearCostmapAroundRobot.srv
+++ b/nav2_msgs/srv/ClearCostmapAroundRobot.srv
@@ -1,6 +1,5 @@
-# Clears the costmap within a window around the robot
+# Clears the costmap within a distance
 
-float32 window_size_x
-float32 window_size_y
+float32 reset_distance
 ---
 std_msgs/Empty response

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -218,7 +218,13 @@ PlannerServer::computePlan()
       action_server_->terminate_all();
       return;
     }
-
+    
+    // Don't compute a plan until costmap is valid (after clear costmap)
+    rclcpp::Rate r(100);
+    while (!costmap_ros_->isCurrent()) {
+      r.sleep();
+    }
+    
     geometry_msgs::msg::PoseStamped start;
     if (!costmap_ros_->getRobotPose(start)) {
       action_server_->terminate_current();


### PR DESCRIPTION
Patched so that re-planning does not occur until a costmap is valid (after costmap clear).